### PR TITLE
Fix Building on OS X Homebrew

### DIFF
--- a/configure
+++ b/configure
@@ -345,7 +345,7 @@ check_pkg_or_exit "libass"
 check_pkg_or_exit "dvdread"
 check_pkg_or_exit "dvdnav"
 check_pkg_or_exit "icu-uc"
-check_pkg_or_exit "chardet"
+check_pkg_or_exit "libchardet"
 if [ $os = "linux" ]; then
         check_pkg_or_exit glib "glib-2.0" "gobject-2.0"
         check_pkg_or_exit "vaapi" "libva" "libva-glx" "libva-x11"

--- a/src/cmplayer/charsetdetector.cpp
+++ b/src/cmplayer/charsetdetector.cpp
@@ -1,5 +1,5 @@
 #include "charsetdetector.hpp"
-#include <chardet.h>
+#include <chardet/chardet.h>
 
 struct CharsetDetector::Data {
 	DetectObj *obj;


### PR DESCRIPTION
These changes adjust how libchardet is accessed in both the configuration
and source files to allow compilation on an OS X system using the
Homebrew system.
