### PR TITLE
Keybindings: Accept inputs with unused modifiers

### DIFF
--- a/src/bomi/player/mainwindow.cpp
+++ b/src/bomi/player/mainwindow.cpp
@@ -354,9 +354,7 @@ auto MainWindow::resizeEvent(QResizeEvent *event) -> void
 auto MainWindow::onKeyPressEvent(QKeyEvent *event) -> void
 {
     QWidget::keyPressEvent(event);
-    constexpr int modMask = Qt::SHIFT | Qt::CTRL | Qt::ALT | Qt::META;
-    const QKeySequence shortcut(event->key() + (event->modifiers() & modMask));
-    d->trigger(RootMenu::instance().action(shortcut));
+    d->trigger(RootMenu::instance().action(event));
     event->accept();
 }
 

--- a/src/bomi/player/rootmenu.cpp
+++ b/src/bomi/player/rootmenu.cpp
@@ -718,3 +718,27 @@ auto RootMenu::action(const QString &longId) const -> QAction*
 {
     return d->find(longId).action;
 }
+
+auto RootMenu::action(const QKeyEvent *event) const -> QAction*
+{
+    std::list<Qt::Modifier> acceptedMod = {Qt::SHIFT, Qt::CTRL, Qt::ALT, Qt::META};
+    QAction *action;
+
+    while (acceptedMod.size()) {
+        auto modMask = std::accumulate(acceptedMod.begin(), acceptedMod.end(), 0x0, [](auto x, auto y) { return x | y; });
+        auto keyCombo = event->key() + (event->modifiers() & modMask);
+
+        if ((action = m_keymap.value(keyCombo))) {
+            _Debug("Found valid key sequence '%%'", QKeySequence(keyCombo).toString());
+            break;
+        } else {
+            // Key sequence not recognized, so ignoring a modifier
+            acceptedMod.pop_front();
+        }
+    }
+
+    if (!action) {
+        _Info("No shortcut found for key sequence '%%'", QKeySequence(event->key() | event->modifiers()).toString());
+    }
+    return action;
+}

--- a/src/bomi/player/rootmenu.hpp
+++ b/src/bomi/player/rootmenu.hpp
@@ -16,6 +16,7 @@ public:
     auto id(QAction *action) const -> QString;
     auto description(const QString &longId) const -> QString;
     auto action(const QString &longId) const -> QAction*;
+    auto action(const QKeyEvent *event) const -> QAction*;
     auto action(const QKeySequence &shortcut) const -> QAction*
         { return m_keymap.value(shortcut); }
     auto resetKeyMap() -> void { m_keymap.clear(); fillKeyMap(this); }


### PR DESCRIPTION
When trying to to trigger 'Show state' by using the key binding `;` when using certain keyboard settings, it generates the sequence `Shift+;`.

The proposed code tries to match a input with a key binding by gradually ignoring modifiers. E.g. `Shift+;` becomes `;` by stripping `Shift`, since there's no binding for `Shift+;`.

Also see https://qt-project.org/doc/qt-5-4/qkeysequence.html#keyboard-layout-issues